### PR TITLE
Add Gemma3n architecture skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,18 @@
 Mojo Models
 
 Serve Custom Models with Mojo - https://docs.modular.com/max/tutorials/serve-custom-model-architectures
+
+## Usage
+
+After logging in to Hugging Face and setting the token:
+
+```bash
+huggingface-cli login --token <TOKEN>
+export HUGGINGFACE_HUB_TOKEN=<TOKEN>
+```
+
+Serve the Gemma3n model with MAX:
+
+```bash
+max serve --model-path google/gemma-3n-E2B-it --custom-architectures gemma3n
+```

--- a/gemma3n/__init__.py
+++ b/gemma3n/__init__.py
@@ -1,0 +1,18 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+
+from .arch import gemma3n_arch
+ARCHITECTURES = [gemma3n_arch]
+
+__all__ = ["gemma3n_arch"]

--- a/gemma3n/arch.py
+++ b/gemma3n/arch.py
@@ -1,0 +1,58 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+
+from max.graph.weights import WeightsFormat
+from max.nn.kv_cache import KVCacheStrategy
+from max.pipelines.core import PipelineTask
+from max.pipelines.lib import (
+    RopeType,
+    SupportedArchitecture,
+    SupportedEncoding,
+    TextTokenizer,
+)
+
+from . import weight_adapters
+from .model import Gemma3nModel
+
+gemma3n_arch = SupportedArchitecture(
+    name="Gemma3ForCausalLM",
+    example_repo_ids=[
+        # it = Instruction tuned (recommended).
+        # pt = Pre-trained.
+        "google/gemma-3n-E2B-it",
+        "google/gemma-3n-E2B-pt",
+        # TODO(MODELS-487): >=4B models have a slightly different architecture
+        # and config and use a different rotary embedding. These will likely
+        # need a separate SupportedArchitecture registration.
+        # "google/gemma-3-4b-it",
+        # "google/gemma-3-4b-pt",
+        # "google/gemma-3-12b-it",
+        # "google/gemma-3-12b-pt",
+        # "google/gemma-3-27b-it",
+        # "google/gemma-3-27b-pt",
+    ],
+    default_encoding=SupportedEncoding.bfloat16,
+    supported_encodings={
+        SupportedEncoding.bfloat16: [KVCacheStrategy.PAGED],
+    },
+    pipeline_model=Gemma3nModel,
+    task=PipelineTask.TEXT_GENERATION,
+    tokenizer=TextTokenizer,
+    default_weights_format=WeightsFormat.safetensors,
+    multi_gpu_supported=False,
+    rope_type=RopeType.normal,
+    weight_adapters={
+        WeightsFormat.safetensors: weight_adapters.convert_safetensor_state_dict,
+    },
+)

--- a/gemma3n/gemma3n.py
+++ b/gemma3n/gemma3n.py
@@ -1,0 +1,232 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Implements the Gemma3n model."""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Sequence
+
+from max.dtype import DType
+from max.graph import TensorValue, TensorValueLike, ops
+from max.nn import MLP, LayerList, Linear, Module
+from max.nn.kv_cache import FetchPagedKVCacheCollection
+from max.nn.rotary_embedding import (
+    Llama3RopeScalingParams,
+    Llama3RotaryEmbedding,
+)
+
+from .layers.attention import _Gemma3nAttention as Gemma3nAttention
+from .layers.rms_norm import Gemma3nRMSNorm
+from .layers.scaled_word_embedding import ScaledWordEmbedding
+from .model_config import Gemma3nConfig
+
+
+class TransformerBlock(Module):
+    """Stack of Attention, FeedForward, and RMSNorm layers.
+
+    Unlike the transformer block in the `max.nn` library, this class applies
+    normalizations to the hidden states immediately after the attention, and
+    before and after the feedforward layers.
+    """
+
+    def __init__(
+        self,
+        attention: Module,
+        mlp: Module,
+        input_layernorm: Module,
+        post_attention_layernorm: Module,
+        pre_feedforward_layernorm: Module,
+        post_feedforward_layernorm: Module,
+    ) -> None:
+        super().__init__()
+        self.self_attn = attention
+        self.mlp = mlp
+        self.input_layernorm = input_layernorm
+        self.post_attention_layernorm = post_attention_layernorm
+        self.pre_feedforward_layernorm = pre_feedforward_layernorm
+        self.post_feedforward_layernorm = post_feedforward_layernorm
+
+    def __call__(
+        self,
+        x: TensorValue,
+        kv_collection: FetchPagedKVCacheCollection,
+        **kwargs,
+    ) -> TensorValue:
+        residual = x
+        attn_out = self.self_attn(
+            self.input_layernorm(x), kv_collection, **kwargs
+        )
+        hidden_states = self.post_attention_layernorm(attn_out)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.pre_feedforward_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = self.post_feedforward_layernorm(hidden_states)
+        return residual + hidden_states
+
+
+class Gemma3nTextModel(Module):
+    """The Gemma 3 language model."""
+
+    def __init__(self, config: Gemma3nConfig) -> None:
+        assert len(config.devices) == 1, (
+            "Only single-device configuration is supported."
+        )
+
+        # Use Llama3RotaryEmbedding for both cases (with and without scaling)
+        scaling_params = (
+            Llama3RopeScalingParams(
+                factor=config.rope_scaling.factor,
+                low_freq_factor=1.0,  # No special scaling for low frequencies
+                high_freq_factor=1.0,  # No special scaling for high frequencies
+                orig_max_position=config.max_position_embeddings,
+            )
+            if config.rope_scaling is not None
+            else None
+        )
+
+        rope_global = Llama3RotaryEmbedding(
+            dim=config.hidden_size,
+            n_heads=config.num_attention_heads,
+            theta=config.rope_theta,
+            max_seq_len=config.max_position_embeddings,
+            device=config.devices[0],
+            head_dim=config.head_dim,
+            interleaved=False,
+            scaling_params=scaling_params,
+        )
+
+        # rope_local doesn't use scaling
+        rope_local = Llama3RotaryEmbedding(
+            dim=config.hidden_size,
+            n_heads=config.num_attention_heads,
+            theta=config.rope_local_base_freq,
+            max_seq_len=config.max_position_embeddings,
+            device=config.devices[0],
+            head_dim=config.head_dim,
+            interleaved=False,
+            scaling_params=None,  # No scaling
+        )
+
+        self.embed_tokens = ScaledWordEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+            config.dtype,
+            config.devices[0],
+            embed_scale=config.hidden_size**0.5,
+        )
+
+        self.norm = Gemma3nRMSNorm(
+            config.hidden_size, config.dtype, config.rms_norm_eps
+        )
+
+        self.lm_head = Linear(
+            config.hidden_size,
+            config.vocab_size,
+            dtype=config.dtype,
+            device=config.devices[0],
+        )
+
+        if config.tie_word_embeddings:
+            self.lm_head.set_shared_weight("weight", self.embed_tokens.weight)
+
+        create_norm = functools.partial(
+            Gemma3nRMSNorm,
+            config.hidden_size,
+            config.dtype,
+            eps=config.rms_norm_eps,
+        )
+
+        layers = [
+            TransformerBlock(
+                attention=Gemma3nAttention(
+                    rope_global=rope_global,
+                    rope_local=rope_local,
+                    num_attention_heads=config.num_attention_heads,
+                    num_key_value_heads=config.num_key_value_heads,
+                    hidden_size=config.hidden_size,
+                    kv_params=config.kv_params,
+                    layer_idx=i,
+                    dtype=config.dtype,
+                    devices=config.devices,
+                    qk_norm_eps=config.rms_norm_eps,
+                ),
+                mlp=MLP(
+                    dtype=config.dtype,
+                    quantization_encoding=None,
+                    hidden_dim=config.hidden_size,
+                    feed_forward_length=config.intermediate_size,
+                    devices=config.devices,
+                    activation_function=config.hidden_activation,
+                ),
+                input_layernorm=create_norm(),
+                post_attention_layernorm=create_norm(),
+                pre_feedforward_layernorm=create_norm(),
+                post_feedforward_layernorm=create_norm(),
+            )
+            for i in range(config.num_hidden_layers)
+        ]
+
+        self.dim = config.hidden_size
+        self.n_heads = config.num_attention_heads
+        self.layers = LayerList(layers)
+        self.norm = self.norm
+        self.lm_head = self.lm_head
+        self.embed_tokens = self.embed_tokens
+        self.kv_params = config.kv_params
+        self.kv_collection_constructor = FetchPagedKVCacheCollection(
+            config.kv_params
+        )
+
+    def __call__(
+        self,
+        tokens: TensorValueLike,
+        kv_cache_inputs: Sequence[TensorValue],
+        **kwargs,
+    ) -> tuple[TensorValue, ...]:
+        h = self.embed_tokens(tokens)
+
+        kv_collection = self.kv_collection_constructor(*kv_cache_inputs)
+        input_row_offsets = kwargs["input_row_offsets"]
+
+        for layer in self.layers:
+            h = layer(h, kv_collection, **kwargs)
+
+        # Retrieve a variable number of tokens
+        last_h = ops.gather(h, input_row_offsets[1:] - 1, axis=0)
+        last_logits = ops.cast(self.lm_head(self.norm(last_h)), DType.float32)
+
+        return (last_logits,)
+
+
+class Gemma3n(Module):
+    """The Gemma model (currently text-only)."""
+
+    def __init__(self, config: Gemma3nConfig) -> None:
+        super().__init__()
+        self.language_model = Gemma3nTextModel(config)
+
+    def __call__(
+        self,
+        tokens: TensorValue,
+        input_row_offsets: TensorValue,
+        kv_cache_inputs: Sequence[TensorValue],
+        return_n_logits: TensorValue,  # Not used for Gemma3n currently
+    ) -> tuple[TensorValue, ...]:
+        return self.language_model(
+            tokens,
+            input_row_offsets=input_row_offsets,
+            kv_cache_inputs=kv_cache_inputs,
+        )

--- a/gemma3n/layers/__init__.py
+++ b/gemma3n/layers/__init__.py
@@ -1,0 +1,14 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Gemma3n layers."""

--- a/gemma3n/layers/attention.py
+++ b/gemma3n/layers/attention.py
@@ -1,0 +1,260 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Gemma3n Attention Layer."""
+
+from __future__ import annotations
+
+import math
+from typing import Callable
+
+from max.dtype import DType
+from max.graph import DeviceRef, TensorValue, Weight, ops
+from max.nn.attention import MHAMaskVariant
+from max.nn.kernels import (
+    flash_attention_ragged,
+    fused_qk_ragged_rope,
+    fused_qkv_ragged_matmul,
+    rms_norm_key_cache,
+)
+from max.nn.kv_cache import (
+    ContinuousBatchingKVCacheCollection,
+    KVCacheParams,
+    PagedKVCacheCollection,
+)
+from max.nn.layer import Module
+from max.nn.linear import Linear
+from max.nn.rotary_embedding import Llama3RotaryEmbedding
+from .rms_norm import Gemma3nRMSNorm
+
+
+class _Gemma3nAttention(Module):
+    """Implementation of the attention layer for the Gemma3n text model."""
+
+    def __init__(
+        self,
+        *,
+        rope_global: Llama3RotaryEmbedding,
+        rope_local: Llama3RotaryEmbedding,
+        num_attention_heads: int,
+        num_key_value_heads: int,
+        hidden_size: int,
+        kv_params: KVCacheParams,
+        layer_idx: int,
+        sliding_window_pattern: int = 6,
+        dtype: DType = DType.float32,
+        devices: list[DeviceRef],
+        linear_cls: Callable[..., Linear] = Linear,
+        scale: float | None = None,
+        has_bias: bool = False,
+        qk_norm_eps: float = 1e-6,
+        local_window_size: int = 1024,
+    ) -> None:
+        """Initializes the attention layer.
+
+        Args:
+            rope_global: Rotary embedding used for global (non-sliding window)
+                attention layers.
+            rope_local: Rotary embedding used for sliding window attention
+                layers.
+            num_attention_heads: The number of attention heads.
+            num_key_value_heads: The number of key/value heads.
+            hidden_size: The dimension of the hidden states.
+            kv_params: KV Cache Params, including the number of kv heads, the
+                head dim, and data type.
+            layer_idx: The layer number associated with this Attention block.
+            dtype: DType of the attention inputs and weights.
+            devices: Device to place the weights and run the computation. If
+                multiple are provided, the first device is used. Use
+                `DistributedAttentionWithRope` to use all devices during
+                attention computation.
+            linear_cls: Linear class to use for the outputs dense layer.
+            scale: Value used to scale the results of the attention output.
+            has_bias: Whether to use an attention bias. Defaults to False.
+            qk_norm_eps: Value to use for numerical stability. Defaults to 1e-6.
+        """
+
+        super().__init__()
+        self.rope_global = rope_global
+        self.rope_local = rope_local
+        self.n_heads = num_attention_heads
+        self.layer_idx = layer_idx
+        self.kv_params = kv_params
+        self.has_bias = has_bias
+        self.devices = devices
+        self.scale = (
+            scale
+            if scale is not None
+            else math.sqrt(1.0 / self.kv_params.head_dim)
+        )
+        self.local_window_size = local_window_size
+        self.sliding_window_pattern = sliding_window_pattern
+        self.qk_norm_eps = qk_norm_eps
+
+        if not self.kv_params.cache_strategy.uses_opaque():
+            raise ValueError(
+                f"{self.kv_params.cache_strategy} cache strategy, not supported"
+                " in Attention layer."
+            )
+
+        self.q_norm = Gemma3nRMSNorm(
+            self.kv_params.head_dim, dtype, self.qk_norm_eps
+        )
+        self.k_norm = Gemma3nRMSNorm(
+            self.kv_params.head_dim, dtype, self.qk_norm_eps
+        )
+        self.q_weight_dim = self.kv_params.head_dim * num_attention_heads
+        self.kv_weight_dim = self.kv_params.head_dim * num_key_value_heads
+
+        self.q_proj = Weight(
+            name="q_proj.weight",
+            dtype=dtype,
+            shape=[self.q_weight_dim, hidden_size],
+            device=devices[0],
+        )
+        self.k_proj = Weight(
+            name="k_proj.weight",
+            dtype=dtype,
+            shape=[self.kv_weight_dim, hidden_size],
+            device=devices[0],
+        )
+        self.v_proj = Weight(
+            name="v_proj.weight",
+            dtype=dtype,
+            shape=[self.kv_weight_dim, hidden_size],
+            device=devices[0],
+        )
+
+        if has_bias:
+            self.bias_q = Weight(
+                name="q_proj.bias",
+                dtype=dtype,
+                shape=[self.q_weight_dim],
+                device=devices[0],
+            )
+            self.bias_k = Weight(
+                name="k_proj.bias",
+                dtype=dtype,
+                shape=[self.kv_weight_dim],
+                device=devices[0],
+            )
+            self.bias_v = Weight(
+                name="v_proj.bias",
+                dtype=dtype,
+                shape=[self.kv_weight_dim],
+                device=devices[0],
+            )
+
+        self.o_proj = linear_cls(
+            in_dim=self.q_weight_dim,
+            out_dim=hidden_size,
+            dtype=dtype,
+            device=devices[0],
+        )
+
+    @property
+    def wqkv(self) -> TensorValue:
+        """The concatenation of q, k, and v weight vectors."""
+        wq: TensorValue = self.q_proj
+        wk: TensorValue = self.k_proj
+        wv: TensorValue = self.v_proj
+        return ops.concat((wq, wk, wv)).to(self.devices[0])
+
+    @property
+    def wqkv_bias(self) -> TensorValue | None:
+        """The concatenation of q, k, and v bias weight vectors."""
+        if not self.has_bias:
+            return None
+
+        return ops.concat((self.bias_q, self.bias_k, self.bias_v))
+
+    def __call__(
+        self,
+        x: TensorValue,
+        kv_collection: ContinuousBatchingKVCacheCollection
+        | PagedKVCacheCollection,
+        **kwargs,
+    ) -> TensorValue:
+        # Get attributes from input.
+        total_seq_len = x.shape[0]
+
+        layer_idx = ops.constant(
+            self.layer_idx, DType.uint32, device=DeviceRef.CPU()
+        )
+        # Call into fused qkv ragged matmul.
+        wqkv = self.wqkv
+        xq = fused_qkv_ragged_matmul(
+            self.kv_params,
+            input=x,
+            wqkv=wqkv,
+            bias=self.wqkv_bias,
+            input_row_offsets=kwargs["input_row_offsets"],
+            kv_collection=kv_collection,
+            layer_idx=layer_idx,
+            n_heads=self.n_heads,
+        )
+        # Apply rope.
+        xq = xq.reshape((-1, self.n_heads, self.kv_params.head_dim))
+
+        # Apply QK norm to query and key states.
+        xq = self.q_norm(xq)
+        rms_norm_key_cache(
+            self.kv_params,
+            kv_collection=kv_collection,
+            gamma=self.k_norm.weight.cast(self.kv_params.dtype).to(
+                self.devices[0]
+            ),
+            epsilon=self.qk_norm_eps,
+            layer_idx=layer_idx,
+            total_seq_len=total_seq_len,
+            input_row_offsets=kwargs["input_row_offsets"],
+            weight_offset=1.0,
+        )
+
+        # Apply rotary embedding.
+        use_local = bool((self.layer_idx + 1) % self.sliding_window_pattern)
+        rope = self.rope_local if use_local else self.rope_global
+
+        if xq.device is not None:
+            freqs_cis = ops.cast(rope.freqs_cis, xq.dtype).to(xq.device)
+        else:
+            freqs_cis = ops.cast(rope.freqs_cis, xq.dtype)
+        xq = fused_qk_ragged_rope(
+            self.kv_params,
+            xq,
+            kwargs["input_row_offsets"],
+            kv_collection,
+            freqs_cis,
+            layer_idx,
+            interleaved=rope.interleaved,
+        )
+
+        # Calculate Flash Attention.
+        mask_variant = (
+            MHAMaskVariant.SLIDING_WINDOW_CAUSAL_MASK
+            if bool((layer_idx + 1) % self.sliding_window_pattern)
+            else MHAMaskVariant.CAUSAL_MASK
+        )
+        attn_out = flash_attention_ragged(
+            self.kv_params,
+            input=xq,
+            kv_collection=kv_collection,
+            layer_idx=layer_idx,
+            input_row_offsets=kwargs["input_row_offsets"],
+            mask_variant=mask_variant,
+            scale=self.scale,
+            local_window_size=self.local_window_size,
+        )
+        attn_out = ops.reshape(attn_out, shape=[total_seq_len, -1])
+        ret = self.o_proj(attn_out)
+        return ret

--- a/gemma3n/layers/rms_norm.py
+++ b/gemma3n/layers/rms_norm.py
@@ -1,0 +1,21 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from max.dtype import DType
+from max.nn.norm.rms_norm import RMSNorm
+
+
+class Gemma3nRMSNorm(RMSNorm):
+    def __init__(self, dim: int, dtype: DType, eps: float = 1e-6) -> None:
+        # Gemma3n uses (1.0 + weight) as the scale factor
+        super().__init__(dim=dim, dtype=dtype, eps=eps, weight_offset=1.0)

--- a/gemma3n/layers/scaled_word_embedding.py
+++ b/gemma3n/layers/scaled_word_embedding.py
@@ -1,0 +1,86 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Scaled Word Embedding."""
+
+from typing import Optional
+
+from max.dtype import DType
+from max.graph import (
+    DeviceRef,
+    TensorValue,
+    TensorValueLike,
+    ops,
+)
+from max.graph.quantization import QuantizationEncoding
+from max.nn.embedding import Embedding
+
+
+class ScaledWordEmbedding(Embedding):
+    """
+    This layer is a wrapper around nn.Embedding that multiplies the embeddings
+    with a scale factor.
+    """
+
+    def __init__(
+        self,
+        vocab_size: int,
+        hidden_dim: int,
+        dtype: DType,
+        device: DeviceRef,
+        quantization_encoding: Optional[QuantizationEncoding] = None,
+        name: Optional[str] = None,
+        embed_scale: float = 1.0,
+    ) -> None:
+        """Initializes the embedding layer with the given arguments.
+
+        Args:
+            vocab_size: The number of unique items in the vocabulary.
+                Indices must be in the range ``[0, vocab_size)``.
+            hidden_dim: The dimensionality of each embedding vector.
+            dtype: The data type of the embedding weights.
+            device: The device where embedding lookups are executed.
+                Model init transfers the initially CPU-resident weights to this
+                device.
+            quantization_encoding: The quantization encoding to use for the
+                embedding weights.
+            name: The name identifier for the embedding weight matrix.
+            embed_scale: The scale to multiply the embeddings with.
+        """
+        super().__init__(
+            vocab_size=vocab_size,
+            hidden_dim=hidden_dim,
+            dtype=dtype,
+            device=device,
+            quantization_encoding=quantization_encoding,
+            name=name,
+        )
+        self.embed_scale = embed_scale
+
+    def __call__(self, indices: TensorValueLike) -> TensorValue:
+        """Embeds the input indices by looking up corresponding vectors, then
+        multiplies the embeddings with the scale factor.
+
+        Args:
+            indices: A tensor of integer indices to look up.
+                Each index must be in the range ``[0, vocab_size)``.
+
+        Returns:
+            A tensor containing the embeddings corresponding to the input
+            indices, multiplied by the scale factor.
+            The result resides on the device specified in :obj:`device`.
+        """
+        result = super().__call__(indices)
+        return result * ops.constant(
+            self.embed_scale, result.dtype, device=result.type.device
+        )

--- a/gemma3n/model.py
+++ b/gemma3n/model.py
@@ -1,0 +1,495 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Sequence
+from typing import cast
+
+import numpy as np
+from max.driver import Device, Tensor
+from max.dtype import DType
+from max.engine import InferenceSession, Model
+from max.graph import DeviceRef, Graph, TensorType
+from max.graph.weights import Weights, WeightsAdapter
+from max.nn import ReturnLogits
+from max.nn.kv_cache import (
+    KVCacheInputs,
+    KVCacheInputsSequence,
+    KVCacheManager,
+    KVCacheParams,
+    estimate_kv_cache_size,
+    load_kv_manager,
+)
+from max.pipelines.core import TextContext
+from max.pipelines.lib import (
+    KVCacheConfig,
+    KVCacheMixin,
+    ModelInputs,
+    ModelOutputs,
+    PipelineConfig,
+    PipelineModel,
+    SupportedEncoding,
+)
+from transformers import AutoConfig
+
+from .gemma3n import Gemma3n
+from .model_config import Gemma3nConfig
+
+logger = logging.getLogger("max.pipelines")
+
+
+class Gemma3nInputs(ModelInputs):
+    """A class representing inputs for the Gemma3n model.
+
+    This class encapsulates the input tensors required for the Gemma3n model
+    execution.
+    """
+
+    tokens: np.ndarray | Tensor
+    """Tensor containing the input token IDs."""
+
+    input_row_offsets: np.ndarray | Tensor
+    """Tensor containing the offsets for each row in the ragged input sequence,
+    or the attention mask for the padded input sequence."""
+
+    def __init__(
+        self,
+        tokens: np.ndarray | Tensor,
+        input_row_offsets: np.ndarray | Tensor,
+        return_n_logits: Tensor,
+        kv_cache_inputs: KVCacheInputs | None = None,
+    ) -> None:
+        """
+        Args:
+            tokens: Input token IDs.
+            input_row_offsets: Input row offsets (ragged tensors).
+            return_n_logits: Number of logits to return.
+            kv_cache_inputs: Inputs for the KV cache.
+        """
+        self.tokens = tokens
+        self.input_row_offsets = input_row_offsets
+        self.kv_cache_inputs = kv_cache_inputs
+        self.return_n_logits = return_n_logits
+
+
+class Gemma3nModel(PipelineModel[TextContext], KVCacheMixin):
+    """A Gemma 3 pipeline model for text generation.
+
+    This class integrates the Gemma 3 architecture with the MAX Engine pipeline
+    infrastructure, handling model loading, KV cache management, and input preparation
+    for inference.
+    """
+
+    model: Model
+    """The compiled and initialized MAX Engine model ready for inference."""
+
+    def __init__(
+        self,
+        pipeline_config: PipelineConfig,
+        session: InferenceSession,
+        huggingface_config: AutoConfig,
+        encoding: SupportedEncoding,
+        devices: list[Device],
+        kv_cache_config: KVCacheConfig,
+        weights: Weights,
+        adapter: WeightsAdapter | None = None,
+        return_logits: ReturnLogits = ReturnLogits.LAST_TOKEN,
+    ) -> None:
+        """
+        Args:
+            pipeline_config: The configuration settings for the entire pipeline.
+            session: The MAX Engine inference session managing the runtime.
+            huggingface_config: The configuration loaded from HuggingFace
+                (:obj:`transformers.AutoConfig`).
+            encoding: The quantization and data type encoding used for the model
+                (:obj:`max.pipelines.config_enums.SupportedEncoding`).
+            devices: A list of MAX Engine devices (:obj:`max.driver.Device`) to
+                run the model on.
+            kv_cache_config: Configuration settings for the Key-Value cache
+                (:obj:`max.pipelines.max_config.KVCacheConfig`).
+            weights: The model weights (:obj:`max.graph.weights.Weights`).
+            adapter: An optional adapter to modify weights before loading
+                (:obj:`max.graph.weights.WeightsAdapter`).
+            return_logits: The number of top logits to return from the model
+                execution.
+        """
+        super().__init__(
+            pipeline_config,
+            session,
+            huggingface_config,
+            encoding,
+            devices,
+            kv_cache_config,
+            weights,
+            adapter,
+            return_logits,
+        )
+
+        self.model = self.load_model(session)
+
+    @staticmethod
+    def calculate_max_seq_len(
+        pipeline_config: PipelineConfig, huggingface_config: AutoConfig
+    ) -> int:
+        """Calculates the maximum sequence length for the Gemma 3 model.
+
+        Uses the `max_length` from the :obj:`max.pipelines.config.PipelineConfig`
+        if provided, otherwise falls back to the `max_position_embeddings` from
+        the HuggingFace configuration's text config.
+
+        Args:
+            pipeline_config: The MAX Engine pipeline configuration.
+            huggingface_config: The HuggingFace model configuration object
+                (:obj:`transformers.AutoConfig`).
+
+        Returns:
+            The calculated maximum sequence length.
+        """
+        max_seq_len = pipeline_config.max_length
+        if max_seq_len:
+            return max_seq_len
+        return huggingface_config.max_position_embeddings
+
+    @classmethod
+    def get_kv_params(
+        cls,
+        huggingface_config: AutoConfig,
+        n_devices: int,
+        kv_cache_config: KVCacheConfig,
+        cache_dtype: DType,
+    ) -> KVCacheParams:
+        """Gets the parameters required to configure the KV cache for Gemma 3.
+
+        Delegates to the :obj:`Gemma3nConfig.get_kv_params` static method.
+
+        Args:
+            huggingface_config: The HuggingFace model configuration object
+                (:obj:`transformers.AutoConfig`).
+            n_devices: The number of devices the model will run on.
+            kv_cache_config: The MAX Engine KV cache configuration settings
+                (:obj:`max.pipelines.max_config.KVCacheConfig`).
+            cache_dtype: The desired data type for the KV cache
+                (:obj:`max.dtype.DType`).
+
+        Returns:
+            The configured :obj:`max.pipelines.kv_cache.KVCacheParams` object.
+        """
+        return Gemma3nConfig.get_kv_params(
+            huggingface_config, n_devices, kv_cache_config, cache_dtype
+        )
+
+    @classmethod
+    def get_num_layers(cls, huggingface_config: AutoConfig) -> int:
+        """Gets the number of hidden layers from the HuggingFace configuration.
+
+        Delegates to the :obj:`Gemma3nConfig.get_num_layers` static method.
+
+        Args:
+            huggingface_config: The HuggingFace model configuration object
+                (:obj:`transformers.AutoConfig`).
+
+        Returns:
+            The number of hidden layers.
+        """
+        return Gemma3nConfig.get_num_layers(huggingface_config)
+
+    @classmethod
+    def estimate_kv_cache_size(
+        cls,
+        pipeline_config: PipelineConfig,
+        available_cache_memory: int,
+        devices: list[Device],
+        huggingface_config: AutoConfig,
+        kv_cache_config: KVCacheConfig,
+        cache_dtype: DType,
+    ) -> int:
+        """Estimates the size of the KV cache required for the Gemma 3 model in bytes.
+
+        Args:
+            pipeline_config: The configuration for the pipeline.
+            available_cache_memory: The total memory available for the KV cache
+                in bytes.
+            huggingface_config: The HuggingFace model configuration object
+                (:obj:`transformers.AutoConfig`).
+            devices: A list of MAX Engine devices (:obj:`max.driver.Device`) the
+                model will run on.
+            kv_cache_config: Configuration settings for the KV cache
+                (:obj:`max.pipelines.max_config.KVCacheConfig`).
+            cache_dtype: The data type for the KV cache (:obj:`max.dtype.DType`).
+
+        Returns:
+            The estimated size of the KV cache in bytes.
+        """
+        return estimate_kv_cache_size(
+            params=Gemma3nConfig.get_kv_params(
+                huggingface_config=huggingface_config,
+                n_devices=len(devices),
+                kv_cache_config=kv_cache_config,
+                cache_dtype=cache_dtype,
+            ),
+            max_batch_size=pipeline_config.max_batch_size,
+            max_seq_len=cls.calculate_max_seq_len(
+                pipeline_config, huggingface_config=huggingface_config
+            ),
+            num_layers=Gemma3nConfig.get_num_layers(
+                huggingface_config=huggingface_config
+            ),
+            available_cache_memory=available_cache_memory,
+            devices=devices,
+        )
+
+    def load_model(self, session: InferenceSession) -> Model:
+        """Loads the compiled Gemma 3 model into the MAX Engine session.
+
+        Note:
+            This method currently returns a dummy Model object and needs to be
+            implemented with the actual graph building and model loading logic
+            for Gemma 3.
+
+        Args:
+            session: The MAX Engine inference session.
+
+        Returns:
+            The loaded MAX Engine model object.
+        """
+        assert self.pipeline_config.max_batch_size, (
+            "Expected max_batch_size to be set"
+        )
+        self._input_row_offsets_prealloc = Tensor.from_numpy(
+            np.arange(self.pipeline_config.max_batch_size + 1, dtype=np.uint32)
+        ).to(self.devices[0])
+
+        logger.info("Building and compiling model...")
+        before = time.perf_counter()
+        graph = self._build_graph()
+        model = session.load(graph, weights_registry=self.state_dict)
+        after = time.perf_counter()
+        logger.info(
+            f"Building and compiling model took {after - before:.6f} seconds"
+        )
+        return model
+
+    # For text-only models, we should be using all the weights.  This is
+    # overridden for Gemma3n multi-modal.
+    _strict_state_dict_loading = True
+
+    def _build_graph(self):
+        device0 = self.devices[0]
+        device_ref = DeviceRef(device0.label, device0.id)
+        tokens_type = TensorType(
+            DType.int64, shape=["total_seq_len"], device=device_ref
+        )
+        # NOTE: input_row_offsets_len should be batch_size + 1.
+        input_row_offsets_type = TensorType(
+            DType.uint32, shape=["input_row_offsets_len"], device=device_ref
+        )
+        return_n_logits_type = TensorType(
+            DType.int64, shape=["return_n_logits"], device=DeviceRef.CPU()
+        )
+
+        huggingface_config = self.huggingface_config
+        if self.adapter:
+            state_dict = self.adapter(
+                dict(self.weights.items()),
+                huggingface_config=huggingface_config,
+                pipeline_config=self.pipeline_config,
+            )
+        else:
+            state_dict = {
+                key: value.data() for key, value in self.weights.items()
+            }
+        model_config = Gemma3nConfig.generate(
+            pipeline_config=self.pipeline_config,
+            huggingface_config=huggingface_config,
+            state_dict=state_dict,
+            dtype=self.dtype,
+            n_devices=len(self.devices),
+            logits_postprocessor=None,
+            attention_bias=huggingface_config.attention_bias,
+            cache_dtype=self.encoding.cache_dtype,
+            kv_cache_config=self.kv_cache_config,
+            return_logits=self.return_logits,
+        )
+        nn_model = Gemma3n(model_config)
+        nn_model.load_state_dict(
+            state_dict,
+            weight_alignment=1,
+            strict=self._strict_state_dict_loading,
+        )
+        self.state_dict = nn_model.state_dict(auto_initialize=False)
+
+        with Graph(
+            getattr(self.huggingface_config, "model_type", "Gemma3n"),
+            input_types=[
+                tokens_type,
+                input_row_offsets_type,
+                return_n_logits_type,
+                *self.kv_manager.input_symbols()[0],
+            ],
+        ) as graph:
+            tokens, input_row_offsets, return_n_logits, *kv_cache_inputs = (
+                graph.inputs
+            )
+            outputs = nn_model(
+                tokens.tensor,
+                input_row_offsets.tensor,
+                [inp.tensor for inp in kv_cache_inputs],
+                return_n_logits=return_n_logits.tensor,
+            )
+            graph.output(*outputs)
+        return graph
+
+    def execute(self, model_inputs: ModelInputs) -> ModelOutputs:
+        """Executes the Gemma 3 model with the prepared inputs.
+
+        Note:
+            This method currently returns dummy output and needs to be implemented
+            with the actual model execution logic for Gemma 3.
+
+        Args:
+            model_inputs: The prepared inputs for the model execution, typically including
+                token IDs, attention masks/offsets, and KV cache inputs.
+
+        Returns:
+            An object containing the output logits from the model execution.
+        """
+        model_inputs = cast(Gemma3nInputs, model_inputs)
+        curr_kv_cache_inputs = model_inputs.kv_cache_inputs or ()
+        model_outputs = self.model.execute(
+            model_inputs.tokens,
+            model_inputs.input_row_offsets,
+            model_inputs.return_n_logits,
+            *curr_kv_cache_inputs,
+        )
+        if len(model_outputs) == 3:
+            return ModelOutputs(
+                logits=cast(Tensor, model_outputs[1]),
+                next_token_logits=cast(Tensor, model_outputs[0]),
+                logit_offsets=cast(Tensor, model_outputs[2]),
+            )
+        else:
+            return ModelOutputs(
+                logits=cast(Tensor, model_outputs[0]),
+                next_token_logits=cast(Tensor, model_outputs[0]),
+            )
+
+    def prepare_initial_token_inputs(
+        self,
+        context_batch: Sequence[TextContext],
+        kv_cache_inputs: KVCacheInputs | None = None,
+        return_n_logits: int = 1,
+    ) -> ModelInputs:
+        """Prepares the initial inputs for the first execution pass of the Gemma 3 model.
+
+        Note:
+            This method currently returns dummy inputs and needs to be implemented
+            with the actual input preparation logic for Gemma 3, considering
+            batching, ragged tensors, and KV cache integration.
+
+        Args:
+            context_batch: A sequence of :obj:`TextContext` objects representing
+                the input prompts.
+            kv_cache_inputs: Optional inputs required by the KV cache manager.
+
+        Returns:
+            The prepared :obj:`ModelInputs` object for the initial execution step.
+        """
+        assert kv_cache_inputs is not None
+        kv_cache_inputs = cast(KVCacheInputsSequence, kv_cache_inputs)
+
+        # This needs to be replaced with actual input preparation
+        # Get input_row_offsets: start and end position of each batch in the
+        # combined total_seq_len dimension.
+        input_row_offsets = np.cumsum(
+            [0] + [ctx.active_length for ctx in context_batch], dtype=np.uint32
+        )
+
+        # Create a ragged token vector of length: sum(len(t) for t in tokens).
+        tokens = np.concatenate([ctx.next_tokens for ctx in context_batch])
+
+        return Gemma3nInputs(
+            tokens=Tensor.from_numpy(tokens).to(self.devices[0]),
+            input_row_offsets=Tensor.from_numpy(input_row_offsets).to(
+                self.devices[0]
+            ),
+            return_n_logits=Tensor.from_numpy(
+                np.array([return_n_logits], dtype=np.int64)
+            ),
+            kv_cache_inputs=kv_cache_inputs,
+        )
+
+    def prepare_next_token_inputs(
+        self, next_tokens: Tensor, prev_model_inputs: ModelInputs
+    ) -> ModelInputs:
+        """Prepares the inputs for subsequent execution steps in a multi-step generation.
+
+        Note:
+            This method currently returns dummy inputs and needs to be implemented
+            with the actual input preparation logic for subsequent steps in Gemma 3,
+            efficiently handling the next token and KV cache updates.
+
+        Args:
+            next_tokens: The tensor containing the token IDs generated in the previous step.
+            prev_model_inputs: The :obj:`ModelInputs` used in the previous execution step.
+
+        Returns:
+            The prepared :obj:`ModelInputs` object for the next execution step.
+        """
+        prev_model_inputs = cast(Gemma3nInputs, prev_model_inputs)
+        row_offsets_size = prev_model_inputs.input_row_offsets.shape[0]
+        next_row_offsets = self._input_row_offsets_prealloc[:row_offsets_size]
+
+        return Gemma3nInputs(
+            tokens=next_tokens,
+            input_row_offsets=next_row_offsets,
+            return_n_logits=prev_model_inputs.return_n_logits,
+            kv_cache_inputs=prev_model_inputs.kv_cache_inputs,
+        )
+
+    def load_kv_manager(
+        self, session: InferenceSession, available_cache_memory: int | None
+    ) -> KVCacheManager:
+        """Loads and initializes the KVCacheManager for the Gemma 3 model.
+
+        Configures the KV cache manager based on model parameters, pipeline settings,
+        and available memory.
+
+        Args:
+            session: The MAX Engine inference session.
+            available_cache_memory: The amount of memory available for the KV cache in bytes.
+
+        Returns:
+            An initialized :obj:`KVCacheManager` instance.
+        """
+        return load_kv_manager(
+            params=Gemma3nConfig.get_kv_params(
+                huggingface_config=self.huggingface_config,
+                n_devices=len(self.devices),
+                kv_cache_config=self.kv_cache_config,
+                cache_dtype=self.encoding.cache_dtype,
+            ),
+            max_batch_size=self.pipeline_config.max_batch_size,
+            max_seq_len=self.calculate_max_seq_len(
+                self.pipeline_config, huggingface_config=self.huggingface_config
+            ),
+            num_layers=Gemma3nConfig.get_num_layers(
+                huggingface_config=self.huggingface_config
+            ),
+            devices=self.devices,
+            available_cache_memory=available_cache_memory,
+            page_size=self.kv_cache_config.kv_cache_page_size,
+            session=session,
+        )

--- a/gemma3n/model_config.py
+++ b/gemma3n/model_config.py
@@ -1,0 +1,315 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Literal
+
+from max.dtype import DType
+from max.graph import DeviceRef, TensorValue
+from max.graph.weights import WeightData, WeightsFormat, weights_format
+from max.nn import LinearScalingParams, ReturnLogits
+from max.nn.kv_cache import KVCacheParams
+from max.pipelines.lib import (
+    KVCacheConfig,
+    MAXModelConfig,
+    MAXModelConfigBase,
+    PipelineConfig,
+    RopeType,
+)
+from transformers import AutoConfig
+
+
+@dataclass
+class Gemma3nConfigBase(MAXModelConfigBase):
+    """Base configuration for Gemma 3 models.
+
+    Contains parameters specific to the Gemma 3 architecture, typically
+    extracted from a HuggingFace configuration object's text config.
+    """
+
+    # Gemma 3 specific parameters (taken from Transformer's `configuration_gemma3.py`)
+    vocab_size: int
+    """Vocabulary size of the Gemma3nText model."""
+
+    hidden_size: int
+    """Dimension of the hidden representations."""
+
+    intermediate_size: int
+    """Dimension of the MLP representations."""
+
+    num_hidden_layers: int
+    """Number of hidden layers in the Transformer decoder."""
+
+    num_attention_heads: int
+    """Number of attention heads for each attention layer in the Transformer
+    decoder."""
+
+    num_key_value_heads: int
+    """Number of key_value heads that should be used to implement Grouped Query
+    Attention."""
+
+    head_dim: int
+    """The attention head dimension."""
+
+    hidden_activation: str
+    """The non-linear activation function (function or string) in the decoder.
+    Will default to `"gelu_tanh"` if not specified. `"gelu_tanh"`
+    uses an approximation of the `"gelu"` activation function."""
+
+    max_position_embeddings: int
+    """The maximum sequence length that this model might ever be used with."""
+
+    rms_norm_eps: float
+    """The epsilon used by the rms normalization layers."""
+
+    tie_word_embeddings: bool
+    """Whether to tie weight embeddings. When true, the output linear layer
+    uses the same
+    weight as the embedding layer."""
+
+    rope_theta: float
+    """The base period of the RoPE embeddings."""
+
+    attention_bias: bool
+    """Whether to use a bias in the query, key, value and output projection
+    layers during self-attention."""
+
+    query_pre_attn_scalar: float | None
+    """Scaling factor used on the attention scores."""
+
+    sliding_window: int
+    """In the Gemma3n language model, every other layer uses sliding window
+    attention. This is the size of the sliding window."""
+
+    final_logit_softcapping: float | None
+    """Scaling factor when applying tanh softcapping on the logits."""
+
+    attn_logit_softcapping: int | None
+    """Scaling factor when applying tanh softcapping on the attention scores."""
+
+    rope_scaling: LinearScalingParams | None
+    """Scaling configuration for the RoPE embeddings used in global attention."""
+
+    rope_local_base_freq: float
+    """The base period of the RoPE embeddings for local attention."""
+
+    sliding_window_pattern: int
+    """Pattern for the sliding window attention."""
+
+    # Max-specific config parameters.
+    dtype: DType
+    """DType of the model weights and input."""
+
+    devices: list[DeviceRef]
+    """Devices to run the model with."""
+
+    interleaved_rope_weights: bool
+    """True if the rope weights are in interleaved complex format."""
+
+    return_logits: ReturnLogits
+    """Whether to return the last token, all logits, or a variable number of logits."""
+
+    kv_params: KVCacheParams
+    """KV cache parameters."""
+
+
+@dataclass
+class Gemma3nConfig(MAXModelConfig, Gemma3nConfigBase):
+    """Represents the complete MAX Engine configuration for Gemma 3 models.
+
+    Combines the base Gemma 3 parameters with MAX-specific settings and
+    provides methods to derive necessary pipeline components like KV cache parameters.
+    """
+
+    @staticmethod
+    def get_kv_params(
+        huggingface_config: AutoConfig,
+        n_devices: int,
+        kv_cache_config: KVCacheConfig,
+        cache_dtype: DType,
+    ) -> KVCacheParams:
+        """Constructs the KV cache parameters from configuration objects.
+
+        Args:
+            huggingface_config: The HuggingFace model configuration object (:obj:`transformers.AutoConfig`).
+            n_devices: The number of devices the model will run on.
+            kv_cache_config: The MAX Engine KV cache configuration settings (:obj:`max.pipelines.max_config.KVCacheConfig`).
+            cache_dtype: The desired data type for the KV cache (:obj:`max.dtype.DType`).
+
+        Returns:
+            The configured :obj:`max.pipelines.kv_cache.KVCacheParams` object.
+        """
+        return KVCacheParams(
+            dtype=cache_dtype,
+            n_kv_heads=huggingface_config.num_key_value_heads,
+            head_dim=huggingface_config.head_dim,
+            page_size=kv_cache_config.kv_cache_page_size,
+            cache_strategy=kv_cache_config.cache_strategy,
+            enable_prefix_caching=kv_cache_config.enable_prefix_caching,
+            enable_kvcache_swapping_to_host=kv_cache_config.enable_kvcache_swapping_to_host,
+            host_kvcache_swap_space_gb=kv_cache_config.host_kvcache_swap_space_gb,
+            n_devices=n_devices,
+        )
+
+    @staticmethod
+    def get_num_layers(huggingface_config: AutoConfig) -> int:
+        """Retrieves the number of hidden layers from the HuggingFace configuration.
+
+        Args:
+            huggingface_config: The HuggingFace model configuration object (:obj:`transformers.AutoConfig`).
+
+        Returns:
+            The number of hidden layers specified in the configuration's text config.
+        """
+        return huggingface_config.num_hidden_layers
+
+    @staticmethod
+    def calculate_max_seq_len(
+        pipeline_config: PipelineConfig, huggingface_config: AutoConfig
+    ) -> int:
+        """Calculates the maximum sequence length for the model.
+
+        Uses the `max_length` from the :obj:`max.pipelines.config.PipelineConfig` if provided,
+        otherwise falls back to the `max_position_embeddings` from the HuggingFace
+        configuration's text config.
+
+        Args:
+            pipeline_config: The MAX Engine pipeline configuration.
+            huggingface_config: The HuggingFace model configuration object (:obj:`transformers.AutoConfig`).
+
+        Returns:
+            The calculated maximum sequence length.
+        """
+        max_seq_len = pipeline_config.max_length
+        if max_seq_len:
+            return max_seq_len
+        return huggingface_config.max_position_embeddings
+
+    @staticmethod
+    def generate(
+        pipeline_config: PipelineConfig,
+        huggingface_config: AutoConfig,
+        state_dict: dict[str, WeightData],
+        dtype: DType,
+        n_devices: int,
+        logits_postprocessor: Callable[[TensorValue], TensorValue] | None,
+        cache_dtype: DType,
+        kv_cache_config: KVCacheConfig,
+        return_logits: ReturnLogits,
+        norm_method: Literal["rms_norm"] = "rms_norm",
+        attention_bias: bool = False,  # Gemma3n attention bias is False in HF.
+    ) -> Gemma3nConfig:
+        """Generates a Gemma3nConfig instance from various configuration sources.
+
+        This factory method takes pipeline settings, HuggingFace configuration,
+        model state dictionary, and other parameters to construct a fully initialized
+        :obj:`Gemma3nConfig` object for use within the MAX Engine pipeline.
+
+        Args:
+            pipeline_config: The MAX Engine pipeline configuration (:obj:`max.pipelines.config.PipelineConfig`).
+            huggingface_config: The HuggingFace model configuration object (:obj:`transformers.AutoConfig`).
+            state_dict: The model's state dictionary containing weights (:obj:`max.graph.weights.WeightData`).
+            dtype: The primary data type for model parameters (:obj:`max.dtype.DType`).
+            n_devices: The number of devices the model will run on.
+            logits_postprocessor: An optional callable to post-process model logits (:obj:`max.graph.TensorValue`).
+            cache_dtype: The data type for the KV cache (:obj:`max.dtype.DType`).
+            kv_cache_config: Configuration settings for the KV cache (:obj:`max.pipelines.max_config.KVCacheConfig`).
+            return_logits: Whether to return the last token, all tokens or a variable number of logits.
+            norm_method: The normalization method to use (currently only "rms_norm").
+            attention_bias: Whether to include bias in attention projections. Defaults
+              to `False` based on Gemma 3 HuggingFace implementation.
+
+        Returns:
+            An initialized :obj:`Gemma3nConfig` instance.
+        """
+        _weights_format = weights_format(
+            pipeline_config.model_config.weight_path
+        )
+        interleaved_rope_weights = (
+            _weights_format == WeightsFormat.gguf
+            and pipeline_config.model_config.rope_type == RopeType.normal
+        )
+        device_refs = [
+            DeviceRef(spec.device_type, spec.id)
+            for spec in pipeline_config.model_config.device_specs
+        ]
+
+        # When tie_word_embeddings=True, the embedding weights are shared with
+        # the output weights.
+        tie_word_embeddings = (
+            getattr(huggingface_config, "tie_word_embeddings", False)
+            or "language_model.lm_head.weight" not in state_dict
+        )
+
+        rope_scaling_params = None
+        rope_scaling = huggingface_config.rope_scaling
+
+        if rope_scaling is not None:
+            # Since "rope_type" huggingface config is not standardized, we need
+            # to check for both "type" and "rope_type" keys.
+            rope_type = rope_scaling.get("type")
+            rope_type_alt = rope_scaling.get("rope_type")
+            if rope_type is None and rope_type_alt is None:
+                raise ValueError(
+                    "Neither 'type' nor 'rope_type' found in rope_scaling huggingface config"
+                )
+            if rope_type == "linear" or rope_type_alt == "linear":
+                rope_scaling_params = LinearScalingParams(
+                    factor=rope_scaling["factor"]
+                )
+
+        hidden_activation = _HIDDEN_ACTIVATION_MAP.get(
+            huggingface_config.hidden_activation,
+            huggingface_config.hidden_activation,
+        )
+
+        return Gemma3nConfig(
+            vocab_size=huggingface_config.vocab_size,
+            hidden_size=huggingface_config.hidden_size,
+            intermediate_size=huggingface_config.intermediate_size,
+            num_hidden_layers=huggingface_config.num_hidden_layers,
+            num_attention_heads=huggingface_config.num_attention_heads,
+            num_key_value_heads=huggingface_config.num_key_value_heads,
+            head_dim=huggingface_config.head_dim,
+            hidden_activation=hidden_activation,
+            max_position_embeddings=huggingface_config.max_position_embeddings,
+            rms_norm_eps=huggingface_config.rms_norm_eps,
+            tie_word_embeddings=tie_word_embeddings,
+            rope_theta=huggingface_config.rope_theta,
+            attention_bias=huggingface_config.attention_bias,
+            query_pre_attn_scalar=huggingface_config.query_pre_attn_scalar,
+            sliding_window=huggingface_config.sliding_window,
+            final_logit_softcapping=huggingface_config.final_logit_softcapping,
+            attn_logit_softcapping=huggingface_config.attn_logit_softcapping,
+            rope_scaling=rope_scaling_params,
+            rope_local_base_freq=huggingface_config.rope_local_base_freq,
+            sliding_window_pattern=huggingface_config.sliding_window_pattern,
+            dtype=dtype,
+            devices=device_refs,
+            interleaved_rope_weights=interleaved_rope_weights,
+            return_logits=return_logits,
+            kv_params=Gemma3nConfig.get_kv_params(
+                huggingface_config=huggingface_config,
+                n_devices=n_devices,
+                kv_cache_config=kv_cache_config,
+                cache_dtype=cache_dtype,
+            ),
+        )
+
+
+_HIDDEN_ACTIVATION_MAP = {
+    "gelu_pytorch_tanh": "gelu_tanh",
+    "swish": "silu",
+}

--- a/gemma3n/weight_adapters.py
+++ b/gemma3n/weight_adapters.py
@@ -1,0 +1,39 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+from max.graph.weights import WeightData, Weights
+
+# Maps from Safetensor to MAX weight names.
+GEMMA3N_SAFETENSOR_MAP: dict[str, str] = {
+    "model.embed_tokens.": "language_model.embed_tokens.",
+    "model.norm.": "language_model.norm.",
+    "lm_head.": "language_model.lm_head.",
+    "model.layers.": "language_model.layers.",
+}
+
+
+def convert_safetensor_state_dict(
+    state_dict: dict[str, Weights], **unused_kwargs
+) -> dict[str, WeightData]:
+    new_state_dict: dict[str, WeightData] = {}
+
+    # Remap HuggingFace -> MAX-style names
+    for weight_name, value in state_dict.items():
+        max_name = weight_name
+        for before, after in GEMMA3N_SAFETENSOR_MAP.items():
+            max_name = max_name.replace(before, after)
+        new_state_dict[max_name] = value.data()
+
+    return new_state_dict


### PR DESCRIPTION
## Summary
- add Gemma3n architecture based on Gemma3
- include layers, model config and weight adapters
- register the architecture so MAX can discover it

## Testing
- `python -m py_compile gemma3n/*.py gemma3n/layers/*.py`
- `max serve --model-path google/gemma-3n-E2B-it --custom-architectures gemma3n` *(fails: 401 Unauthorized)*

------
https://chatgpt.com/codex/tasks/task_e_685f9743411c8332b72a1deb3180eee6